### PR TITLE
Fix path manipulation for OS portability

### DIFF
--- a/transpose_all_keys.py
+++ b/transpose_all_keys.py
@@ -32,6 +32,6 @@ for file in glob.glob(sys.argv[1] + "/*.mid"):
         new_key = keys[ (key_index + i) % 12]
         folder = f'{new_key} {key.mode}'
         check_or_create_folder( sys.argv[2] + '/' + folder)
-        file_name = file.split('\\')[-1]
+        file_name = os.path.split(file)[-1]
         newFileName = f'{sys.argv[2]}/{folder}/{file_name}'
         newscore.write('midi',newFileName)

--- a/transpose_to_C_or_Am.py
+++ b/transpose_to_C_or_Am.py
@@ -30,9 +30,9 @@ for file in glob.glob(sys.argv[1] + "/*.mid"):
     
     if key.mode == "minor":
         check_or_create_folder(sys.argv[2] + '/Am')
-        newFileName = sys.argv[2] + "/Am/" + file.split('\\')[-1]
+        newFileName = sys.argv[2] + "/Am/" + os.path.split(file)[-1]
         newscore.write('midi',newFileName)
     if key.mode == "major":
         check_or_create_folder(sys.argv[2] + '/C')
-        newFileName = sys.argv[2] + "/C/" + file.split('\\')[-1]
+        newFileName = sys.argv[2] + "/C/" + os.path.split(file)[-1]
         newscore.write('midi',newFileName)


### PR DESCRIPTION
Replacing split() method for os.path.split(), to work properly on other OS's.